### PR TITLE
 Fix(vax): reconnect to antidote in case of failure 

### DIFF
--- a/apps/vax/lib/vax/connection_pool.ex
+++ b/apps/vax/lib/vax/connection_pool.ex
@@ -1,21 +1,74 @@
 defmodule Vax.ConnectionPool do
   @behaviour NimblePool
 
+  alias Vax.ConnectionPool.BackoffWorker
+
   @spec checkout(pid() | atom(), ({pid(), reference()}, pid() -> {term(), pid()})) :: term()
   def checkout(pool, fun, _opts \\ []) do
     NimblePool.checkout!(pool, :checkout, fun)
+  end
+
+  @spec child_spec(Keyword.t()) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    repo = Keyword.fetch!(opts, :repo)
+
+    children = [
+      %{
+        id: BackoffWorker,
+        start: {BackoffWorker, :start_link, [Keyword.put(opts, :name, backoff_worker_name(repo))]}
+      },
+      DynamicSupervisor.child_spec(
+        name: connection_supervisor_name(repo),
+        strategy: :one_for_one
+      ),
+      %{
+        id: __MODULE__,
+        start:
+          {NimblePool, :start_link,
+           [
+             [
+               name: pool_name(repo),
+               worker: {__MODULE__, [hostname: opts[:hostname], port: opts[:port], repo: repo]},
+               pool_size: opts[:pool_size] || 10
+             ]
+           ]}
+      }
+    ]
+
+    %{
+      id: ConnectionPoolSupervisor,
+      start: {Supervisor, :start_link, [children, [strategy: :one_for_one]]}
+    }
   end
 
   @impl true
   def init_worker(pool_state) do
     hostname = Keyword.fetch!(pool_state, :hostname)
     port = Keyword.fetch!(pool_state, :port)
+    repo = Keyword.fetch!(pool_state, :repo)
 
-    # Starting the protobuf socket is blocking, so we use NimblePool async
-    # initialization
+    # Starting the protobufWorker socket is blocking, so we use NimblePool async
+    # initialization. Before starting, backoff worker is requested to check whether
+    # sleeping is needed.
     init_fun = fn ->
-      {:ok, socket_pid} = :antidotec_pb_socket.start_link(hostname, port)
-      %{pb_socket: socket_pid}
+      backoff_worker = backoff_worker_name(repo)
+      connection_supervisor = connection_supervisor_name(repo)
+      BackoffWorker.wait_for_backoff(backoff_worker)
+
+      pb_socket_child_spec = %{
+        id: __MODULE__,
+        start: {:antidotec_pb_socket, :start_link, [hostname, port]},
+        restart: :temporary
+      }
+
+      case DynamicSupervisor.start_child(connection_supervisor, pb_socket_child_spec) do
+        {:ok, socket_pid} ->
+          %{pb_socket: socket_pid}
+
+        error ->
+          BackoffWorker.register_failure(backoff_worker)
+          raise "Failed to connect to antidote with error #{inspect(error)}"
+      end
     end
 
     {:async, init_fun, pool_state}
@@ -23,6 +76,25 @@ defmodule Vax.ConnectionPool do
 
   @impl true
   def handle_checkout(_maybe_wrapped_command, _from, worker_state, pool_state) do
-    {:ok, worker_state.pb_socket, worker_state, pool_state}
+    if Process.alive?(worker_state.pb_socket) do
+      {:ok, worker_state.pb_socket, worker_state, pool_state}
+    else
+      {:remove, :dead, pool_state}
+    end
+  end
+
+  @spec backoff_worker_name(atom()) :: atom()
+  defp backoff_worker_name(repo) do
+    Module.concat([repo, BackoffWorker])
+  end
+
+  @spec connection_supervisor_name(atom()) :: atom()
+  defp connection_supervisor_name(repo) do
+    Module.concat([repo, ConnectionSupervisor])
+  end
+
+  @spec pool_name(atom()) :: atom()
+  def pool_name(repo) do
+    Module.concat([repo, __MODULE__])
   end
 end

--- a/apps/vax/lib/vax/connection_pool/backoff_worker.ex
+++ b/apps/vax/lib/vax/connection_pool/backoff_worker.ex
@@ -1,0 +1,73 @@
+defmodule Vax.ConnectionPool.BackoffWorker do
+  @moduledoc false
+
+  use GenServer
+
+  @backoff_reset_interval_ms 60_000
+  @default_max_backoff_ms 5_000
+
+  @type state :: %{
+          last_failure: integer() | nil,
+          last_backoff: integer() | nil,
+          max_backoff: integer(),
+          backoff_reset_interval: integer()
+        }
+
+  @spec start_link(Keyword.t()) :: GenServer.on_start()
+  def start_link(opts) do
+    {name, opts} = Keyword.pop(opts, :name)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @spec wait_for_backoff(pid() | atom()) :: :ok
+  def wait_for_backoff(pid_or_name) do
+    pid_or_name
+    |> GenServer.call(:reconnection_backoff)
+    |> :timer.sleep()
+  end
+
+  @spec wait_for_backoff(pid() | atom()) :: :ok
+  def register_failure(pid_or_name) do
+    GenServer.cast(pid_or_name, :register_failure)
+  end
+
+  @impl GenServer
+  def init(opts) do
+    max_backoff = Keyword.get(opts, :max_backoff, @default_max_backoff_ms)
+
+    backoff_reset_interval =
+      Keyword.get(opts, :backoff_reset_interval, @backoff_reset_interval_ms)
+
+    {:ok,
+     %{
+       last_failure: nil,
+       last_backoff: nil,
+       max_backoff: max_backoff,
+       backoff_reset_interval: backoff_reset_interval
+     }}
+  end
+
+  @impl GenServer
+  def handle_call(:reconnection_backoff, _from, state) do
+    new_backoff = compute(state)
+    {:reply, new_backoff, %{state | last_backoff: new_backoff}}
+  end
+
+  @impl GenServer
+  def handle_cast(:register_failure, state) do
+    {:noreply, %{state | last_failure: System.monotonic_time(:millisecond)}}
+  end
+
+  @spec compute(state()) :: integer()
+  defp compute(%{last_failure: nil}) do
+    0
+  end
+
+  defp compute(state) do
+    if System.monotonic_time(:millisecond) - state.last_failure >= state.backoff_reset_interval do
+      0
+    else
+      min(state.last_backoff + 500, state.max_backoff)
+    end
+  end
+end


### PR DESCRIPTION
- When the pool perceives a connection is dead, the connection
 is removed and the checkout goes to the next; Initialization
 of a new connection is scheduled.
- If fail at connecting, sleep for **backoff** before retrying;
- Disconnections are only perceived at connection checkout time