### PR TITLE
[VAX-82] Add dialyzer pass for Vax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,13 @@ docs:
 xref: compile
 	${REBAR} xref skip_deps=true
 
-dialyzer:
+dialyzer: dialyzer-vaxine dialyzer-vax
+
+dialyzer-vaxine:
 	${REBAR} dialyzer
+
+dialyzer-vax:
+	make dialyzer -C apps/vax
 
 docker-build:
 	tmpdir=`mktemp -d` ; \

--- a/apps/antidotec_pb/src/antidotec_counter.erl
+++ b/apps/antidotec_pb/src/antidotec_counter.erl
@@ -98,6 +98,8 @@ is_type(T) ->
 type() ->
     counter.
 
+-spec to_ops(term(), antidotec_counter()) ->
+          [{term(), increment | decrement, integer()}].
 to_ops(_BoundObject, #counter{increment = 0}) ->
     [];
 to_ops(BoundObject, #counter{increment = Amount}) when Amount < 0 ->

--- a/apps/vax/Makefile
+++ b/apps/vax/Makefile
@@ -16,6 +16,9 @@ compile: deps
 test:
 	mix test
 
+dialyzer:
+	mix dialyzer
+
 clean:
 	mix clean
 

--- a/apps/vax/dialyzer.ignore-warnings
+++ b/apps/vax/dialyzer.ignore-warnings
@@ -1,0 +1,6 @@
+lib/vax/adapter/helpers.ex:52: The created fun has no local return
+lib/vax/adapter/helpers.ex:57: Function build_update_map/3 has no local return
+lib/vax/adapter/helpers.ex:66: Function update_map_value/5 has no local return
+lib/vax/adapter/helpers.ex:74: The call antidotec_map:add_or_update(_map@1::tuple(),_map_key@1::{binary(),_},_value@1::any()) does not have an opaque term of type antidotec_map:antidote_map() as 1st argument
+lib/vax/adapter/helpers.ex:97: Function to_antidotec_map/2 has no local return
+lib/vax/adapter/helpers.ex:110: The call erlang:element(1,_map@1::antidotec_map:antidote_map()) contains an opaque term as 2nd argument when terms of different types are expected in these position

--- a/apps/vax/lib/vax/adapter.ex
+++ b/apps/vax/lib/vax/adapter.ex
@@ -219,7 +219,7 @@ defmodule Vax.Adapter do
 
   @impl Ecto.Adapter.Storage
   def storage_status(_) do
-    :ok
+    :up
   end
 
   @doc """

--- a/apps/vax/lib/vax/adapter/helpers.ex
+++ b/apps/vax/lib/vax/adapter/helpers.ex
@@ -30,7 +30,7 @@ defmodule Vax.Adapter.Helpers do
   @spec load_map(
           repo :: atom(),
           schema :: Ecto.Schema.t(),
-          antidote_map :: :antidotec_map.antidotec_map()
+          antidote_map :: :antidotec_map.antidote_map()
         ) :: struct() | nil
   def load_map(repo, schema, map) do
     map

--- a/apps/vax/lib/vax/types/counter.ex
+++ b/apps/vax/lib/vax/types/counter.ex
@@ -43,7 +43,7 @@ defmodule Vax.Types.Counter do
 
   @impl Vax.Type
   def compute_change(antidotec_counter, new_value) do
-    old_value = :antidotec_counter.value(antidotec_counter) || 0
+    old_value = :antidotec_counter.value(antidotec_counter)
 
     if old_value > new_value do
       :antidotec_counter.decrement(old_value - new_value, antidotec_counter)

--- a/apps/vax/mix.exs
+++ b/apps/vax/mix.exs
@@ -9,7 +9,8 @@ defmodule Vax.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(Mix.env()),
       package: package(),
-      test_paths: ["test"]
+      test_paths: ["test"],
+      dialyzer: [ignore_warnings: "dialyzer.ignore-warnings"]
     ] ++ docs()
   end
 

--- a/apps/vax/mix.exs
+++ b/apps/vax/mix.exs
@@ -33,7 +33,8 @@ defmodule Vax.MixProject do
       {:ecto, "~> 3.7"},
       {:antidote_pb_codec, path: "../antidote_pb_codec", override: true},
       {:antidotec_pb, path: "../antidotec_pb"},
-      {:nimble_pool, "~> 0.2.6"}
+      {:nimble_pool, "~> 0.2.6"},
+      {:dialyxir, "~> 1.0", only: [:dev], runtime: false}
     ]
   end
 

--- a/apps/vax/mix.lock
+++ b/apps/vax/mix.lock
@@ -1,6 +1,8 @@
 %{
   "decimal": {:hex, :decimal, "2.0.0", "a78296e617b0f5dd4c6caf57c714431347912ffb1d0842e998e9792b5642d697", [:mix], [], "hexpm", "34666e9c55dea81013e77d9d87370fe6cb6291d1ef32f46a1600230b1d44f577"},
+  "dialyxir": {:hex, :dialyxir, "1.1.0", "c5aab0d6e71e5522e77beff7ba9e08f8e02bad90dfbeffae60eaf0cb47e29488", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "07ea8e49c45f15264ebe6d5b93799d4dd56a44036cf42d0ad9c960bc266c0b9a"},
   "ecto": {:hex, :ecto, "3.8.3", "5e681d35bc2cbb46dcca1e2675837c7d666316e5ada14eca6c9c609b6232817c", [:mix], [{:decimal, "~> 1.6 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}, {:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "af92dd7815967bcaea0daaaccf31c3b23165432b1c7a475d84144efbc703d105"},
+  "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
   "nimble_pool": {:hex, :nimble_pool, "0.2.6", "91f2f4c357da4c4a0a548286c84a3a28004f68f05609b4534526871a22053cde", [:mix], [], "hexpm", "1c715055095d3f2705c4e236c18b618420a35490da94149ff8b580a2144f653f"},
   "telemetry": {:hex, :telemetry, "1.1.0", "a589817034a27eab11144ad24d5c0f9fab1f58173274b1e9bae7074af9cbee51", [:rebar3], [], "hexpm", "b727b2a1f75614774cff2d7565b64d0dfa5bd52ba517f16543e6fc7efcc0df48"},
 }


### PR DESCRIPTION
Current usage for antidotec_map breaks opaqueness. Ignore this issue in this PR, we should address it in a separate ticket. Preferable we should just use `antidotec_map:new/1` with proper value and do not create record on the fly.

Reminder about opaque types - we can not inspect them outside of the module they were defined. If we really need to do something with them (for instance to compare them with `undefined` value) we need to either drop opaqueness, or introduce conversion functions `to_map`, or introduce helper functions, like `is_empty`.

For now dialyzer pass is independent for Vax and Vaxine, me can address that in the future.