### PR TITLE
Fix ordering issue in vector_orddict

### DIFF
--- a/apps/antidote/rebar.config
+++ b/apps/antidote/rebar.config
@@ -1,5 +1,6 @@
 {erl_opts, [debug_info]}.
 {plugins, [rebar3_path_deps]}.
+{project_plugins, [rebar3_proper]}.
 
 {deps, [
     {antidote_crdt, {path, "../antidote_crdt"}},
@@ -19,7 +20,7 @@
     {test, [
         {extra_src_dirs, [{"test", [{recursive, true}]}]},
         {erl_opts, [warnings_as_errors, debug_info, no_inline_list_funcs]},
-        {deps, [meck]}
+        {deps, [meck, proper]}
     ]}
 ]}.
 

--- a/apps/antidote/src/vector_orddict.erl
+++ b/apps/antidote/src/vector_orddict.erl
@@ -121,7 +121,7 @@ insert(Vector, Val, {List, Size}) ->
 insert_internal(Vector, Val, [], Size, PrevList) ->
     {lists:reverse([{Vector, Val} | PrevList]), Size};
 insert_internal(Vector, Val, [{FirstClock, FirstVal} | Rest], Size, PrevList) ->
-    case vectorclock:all_dots_greater(Vector, FirstClock) of
+    case vectorclock:all_dots(Vector, FirstClock, fun erlang:'>='/2) of
         true ->
             {lists:reverse(PrevList, [{Vector, Val} | [{FirstClock, FirstVal} | Rest]]), Size};
         false ->
@@ -286,5 +286,20 @@ vector_orddict_conc_test() ->
 
     ?assertEqual(is_concurrent_with_any(VDict, CT1), false),
     ?assertEqual(is_concurrent_with_any(VDict, CT2), true).
+
+vector_orddict_simple_ordering_test() ->
+    Q0 = vector_orddict:new(),
+    Q1 = vector_orddict:insert(#{dc1 => 1, dc2 => 1}, val1, Q0),
+    Q2 = vector_orddict:insert(#{dc1 => 1, dc2 => 2}, val2, Q1),
+    ?assertEqual({#{dc1 => 1, dc2 => 2}, val2},
+                 vector_orddict:first(Q2)).
+
+vector_orddict_simple_ordering2_test() ->
+    Q0 = vector_orddict:new(),
+    Q1 = vector_orddict:insert(#{dc1 => 1, dc2 => 2}, val2, Q0),
+    Q2 = vector_orddict:insert(#{dc1 => 1, dc2 => 1}, val1, Q1),
+    ?assertEqual({#{dc1 => 1, dc2 => 2}, val2},
+                 vector_orddict:first(Q2)).
+
 
 -endif.

--- a/apps/vectorclock/src/vectorclock.erl
+++ b/apps/vectorclock/src/vectorclock.erl
@@ -28,6 +28,7 @@
 -export([
     all_dots_greater/2,
     all_dots_smaller/2,
+    all_dots/3,
     conc/2,
     eq/2,
     fold/3,
@@ -179,6 +180,11 @@ all_dots_smaller(V1, V2) ->
 -spec all_dots_greater(vectorclock(), vectorclock()) -> boolean().
 all_dots_greater(V1, V2) ->
     for_all_keys(fun(A, B) -> A > B end, V1, V2).
+
+-spec all_dots(vectorclock(), vectorclock(), fun((integer(), integer()) -> boolean())) ->
+          boolean().
+all_dots(V1, V2, CompFun) ->
+    for_all_keys(fun(A, B) -> CompFun(A, B) end, V1, V2).
 
 -spec gt(vectorclock(), vectorclock()) -> boolean().
 gt(V1, V2) -> lt(V2, V1).


### PR DESCRIPTION
In the current master vector_orddict:insert function would compare all dots for `>`, rather then `>=`, which will lead to a wrong ordering of vv, such as: if given
`#{dc1 => 1, dc2 => 1}` and `#{dc1 => 1, dc=> 2}`, the `vector_orddict` internal ordering would be dependent on the insert order, and `vector_orddict:first` would give different results.