### PR TITLE
Interactive transactions on Vax

### DIFF
--- a/apps/vax/lib/vax/adapter/antidote_client.ex
+++ b/apps/vax/lib/vax/adapter/antidote_client.ex
@@ -32,6 +32,15 @@ defmodule Vax.Adapter.AntidoteClient do
     end)
   end
 
+  @spec commit_transaction(conn :: pid(), tx_id :: term()) ::
+          {:ok, tx_id :: binary()} | {:error, term()}
+  def commit_transaction(conn, tx_id) do
+    :telemetry.span([:vax, :commit_transaction], %{tx_id: tx_id}, fn ->
+      result = :antidotec_pb.commit_transaction(conn, tx_id)
+      {result, %{tx_id: tx_id}}
+    end)
+  end
+
   defp start_transaction_metadata(last_tx_id, result \\ nil)
 
   defp start_transaction_metadata(last_tx_id, {:ok, tx_id}),

--- a/apps/vax/lib/vax/adapter/logger.ex
+++ b/apps/vax/lib/vax/adapter/logger.ex
@@ -11,7 +11,8 @@ defmodule Vax.Adapter.Logger do
       [
         [:vax, :read_objects, :stop],
         [:vax, :update_objects, :stop],
-        [:vax, :start_transaction, :stop]
+        [:vax, :start_transaction, :stop],
+        [:vax, :commit_transaction, :stop]
       ],
       &__MODULE__.handle_event/4,
       nil
@@ -69,6 +70,19 @@ defmodule Vax.Adapter.Logger do
     |> Logger.debug()
   end
 
+  def handle_event([:vax, :commit_transaction, :stop], measurements, metadata, _handler_meta) do
+    [
+      "Vax",
+      " - ",
+      "COMMIT TRANSACTION",
+      " - ",
+      "Took #{duration_to_binary(measurements.duration)} ",
+      " - Transaction id: ",
+      tx_id_to_binary(metadata.tx_id)
+    ]
+    |> Logger.debug()
+  end
+
   defp objects_to_iolist(objects) do
     Enum.map(objects, fn {key, _type, _bucket} -> "\n- " <> key end)
   end
@@ -91,5 +105,6 @@ defmodule Vax.Adapter.Logger do
     "#{duration_in_us} μs"
   end
 
-  defp tx_id_to_binary({_kind, {tx_vector_clock, _opts}}), do: inspect(tx_vector_clock)
+  defp tx_id_to_binary({:static, {tx_vector_clock, _opts}}), do: inspect(tx_vector_clock)
+  defp tx_id_to_binary({:interactive, tx_vector_clock}), do: inspect(tx_vector_clock)
 end


### PR DESCRIPTION
Implements Ecto.Adapter.Transaction using :antidotec_pb interactive
transaction API. As all antidote calls must be done within a
transaction, a static transaction is opened if no explicit call
of `Repo.transaction/1` is made.Transaction nesting is allowed
in regular Ecto fashion.