### PR TITLE
Use version from git for application and release, instead of hardcoded one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ shell: rel
 	export NODE_NAME=antidote@127.0.0.1 ; \
 	export COOKIE=antidote ; \
 	export ROOT_DIR_PREFIX=$$NODE_NAME/ ; \
-	_build/default/rel/antidote/bin/antidote console ${ARGS}
+	_build/default/rel/vaxine/bin/vaxine console ${ARGS}
 
 rel:
 	$(REBAR) release

--- a/apps/vx_server/src/vx_server.app.src
+++ b/apps/vx_server/src/vx_server.app.src
@@ -1,6 +1,6 @@
 {application, vx_server,
  [{description, "An OTP application"},
-  {vsn, "0.1.0"},
+  {vsn, "git"},
   {registered, []},
   {mod, {vx_server_app, []}},
   {applications,

--- a/rebar.config
+++ b/rebar.config
@@ -60,7 +60,7 @@
 ]}.
 
 {relx, [
-    {release, {vaxine, "0.1.0"}, [vx_server]},
+    {release, {vaxine, git}, [vx_server]},
     {dev_mode, false},
     % do not expect Erlang runtime at deployment site
     {include_erts, true},


### PR DESCRIPTION
Change verion for both app/release to git tag/tag+commit
https://rebar3.readme.io/docs/releases#getting-started

@bieniusa you might want to incorporate the same versioning strategy.