### PR TITLE
VAX-490: Materialize transaction only when the cache has been updated up to global op id.

### DIFF
--- a/apps/vx_server/src/vx_wal_stream.erl
+++ b/apps/vx_server/src/vx_wal_stream.erl
@@ -378,8 +378,12 @@ is_materialization_ready(Partition, #wal_trans{snapshot = TxST, dcid = DcId, glo
     case compare_snapshot(SN, TxST) of
         true -> true;
         false ->
-            GId = lookup_last_cache_global_opid(Partition, DcId),
-            OpId =< GId
+            case lookup_last_cache_global_opid(Partition, DcId) of
+                undefined ->
+                    false;
+                #op_number{global = GId} ->
+                    OpId =< GId
+            end
     end.
 
 compare_snapshot(SN, TxST) ->

--- a/config/network.config
+++ b/config/network.config
@@ -19,6 +19,10 @@
 
   {antidote_stats, [
     {metrics_port, 3001}
+  ]},
+
+  {vx_server, [
+    {pb_port, 8088}
   ]}
 
 %%  possible to restrict distributed Erlang ports

--- a/config/sys.config.src
+++ b/config/sys.config.src
@@ -80,7 +80,7 @@
     %%        true -> write operations are certified during commit, aborting the transaction if a write conflict is detected (i.e. snapshot isolation
     %%                is ensured for the updates within a single DC, updates across DCs are not checked)
     %%        false -> transactions perform no certification and always commit (outside of crashes/errors)
-    %{txn_cert, true},
+    {txn_cert, true},
 
     %% txn_prot:
     %%        clocksi -> uses "Cure" protocol to define snapshots and causal dependencies (https://pages.lip6.fr/Marc.Shapiro/papers/Cure-final-ICDCS16.pdf)
@@ -90,31 +90,31 @@
     %% recover_from_log:
     %%        true -> on node start will load any operations stored on the disk log to the in memory cache of the key-value store
     %%        false -> on node start the state of the key-value store will be empty
-    %{recover_from_log, true},
+    {recover_from_log, true},
 
     %% recover_meta_data_on_start:
     %%        true -> meta-data state will be loaded from disk on restart including connection state between other DCs and node names and configurations,
     %%                nodes will automatically reconnect to other dcs on restart
     %%        false -> meta-data concerning node names and connections to other dcs will not be loaded on restart
-    %{recover_meta_data_on_start, true},
+    {recover_meta_data_on_start, true},
 
     %% sync_log:
     %%        true -> local transactions will be stored on log synchronously, i.e. when the reply is sent the updates are guaranteed to be
     %%                stored to disk (this is very slow in the current logging setup)
     %%        false -> all updates are sent to the operating system to be stored to disk (eventually), but are not guaranteed to be stored durably on disk
     %%                 when the reply is sent
-    {sync_log, true}
+    {sync_log, true},
 
     %% %% enable_logging:
     %%        true -> writes to disk done by the logging_vnode are enabled
     %%        false -> writes to disk are disabled, this improves performance when benchmarking.
     %%        WARNING: disabling logging makes updates non-recoverable after shutting down antidote or under failures.
-    %{enable_logging, true},
+    {enable_logging, true},
 
     %% %% auto_start_read_servers:
     %%        true -> read servers will start automatically. It should be set to true when Antidote will be run in a single node/machine.
     %%        false -> read servers will not start automatically. It should be set to false when many Antidote instances will be run in a cluster.
     %%                 In this case, a inter_dc_manager:start_bg_processes(stable) needs to be issued per antidote instance after joining the cluster.
-    %{auto_start_read_servers, true}
+    {auto_start_read_servers, true}
   ]}
 ].


### PR DESCRIPTION


    Fix in vx wal stream - previously global operation id check was always passing
    if snapshot was stale. That has been fixed in vx_server application.

    When receiving transactions from remote DCs global value of operation was not
    updated, leading to non-monotonically increased values. Thus relying on that
    value in vx_server was leading to errors. This was fixed, so that for remote dcs
    operation number is combination of the monotonically increasing value within
    local dc (global) and monotonically increasing value for transactions originated
    in remote dc (local).